### PR TITLE
RHMAP-1516 : add listener for sync events

### DIFF
--- a/www/app/workorder/workorder.js
+++ b/www/app/workorder/workorder.js
@@ -25,9 +25,13 @@ angular.module('wfm-mobile.workorders', [
       })
 })
 
-.controller('WorkordersCtrl', function(mediator, workorders) {
+.controller('WorkordersCtrl', function($scope,mediator, workorders) {
   var self = this;
   self.workorders = workorders;
+  mediator.subscribe('workorders:refreshed', function(results){
+    self.workorders = results;
+    $scope.$apply();
+  })
 })
 
 ;


### PR DESCRIPTION
For now, that's how we "refresh" the mobile client after a sync event. In the short term, I hope we will be able to hide this into the wororder module but not sure it's possible.
