### PR TITLE
add Node Security Platform (NSP) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ node_js:
   - '4.4'
 scripts:
   - npm test
+  - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 before_install:
   - npm install fh-build -g
+  - npm install nsp -g
   - fh-build template
 install: npm install
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 node_js:
   - '0.10'
   - '4.4'
-scripts:
+script:
   - npm test
   - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1018,9 +1018,9 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "tough-cookie": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.2",
@@ -1130,9 +1130,9 @@
                       }
                     },
                     "negotiator": {
-                      "version": "0.4.9",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                      "version": "0.6.1",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
@@ -1147,9 +1147,9 @@
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
                 },
                 "cookie-signature": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 },
                 "debug": {
                   "version": "2.1.3",
@@ -1157,9 +1157,9 @@
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
                   "dependencies": {
                     "ms": {
-                      "version": "0.7.0",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
@@ -1260,9 +1260,9 @@
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
                 },
                 "send": {
-                  "version": "0.10.1",
-                  "from": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.10.1.tgz",
+                  "version": "0.14.1",
+                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.3",
@@ -1270,9 +1270,9 @@
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                     },
                     "ms": {
-                      "version": "0.6.2",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                      "version": "0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "on-finished": {
                       "version": "2.1.1",
@@ -1352,9 +1352,9 @@
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.7",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "rc": {
                   "version": "0.1.1",
@@ -1507,9 +1507,9 @@
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
                 },
                 "hawk": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "version": "3.1.3",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "dependencies": {
                     "boom": {
                       "version": "0.4.2",
@@ -1566,9 +1566,9 @@
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
                 },
                 "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                  "version": "1.4.7",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
                 },
                 "oauth-sign": {
                   "version": "0.3.0",
@@ -1586,9 +1586,9 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "tough-cookie": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.1",
@@ -1664,9 +1664,9 @@
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         },
         "moment": {
-          "version": "2.0.0",
-          "from": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.0.0.tgz"
+          "version": "2.15.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
         },
         "mongodb-uri": {
           "version": "0.9.7",
@@ -2111,9 +2111,9 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
                 "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
                 },
                 "tunnel-agent": {
                   "version": "0.4.2",
@@ -2363,9 +2363,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "moment": {
-      "version": "2.8.4",
-      "from": "moment@>=2.8.4 <2.9.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.4.tgz"
+      "version": "2.15.1",
+      "from": "moment@2.15.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz"
     },
     "ms": {
       "version": "0.7.1",
@@ -2378,9 +2378,9 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz"
     },
     "negotiator": {
-      "version": "0.5.3",
-      "from": "negotiator@0.5.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+      "version": "0.6.1",
+      "from": "negotiator@0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
     },
     "ng-feedhenry": {
       "version": "0.2.53",


### PR DESCRIPTION
Motivation:
To help identify/discover known vulnerabilities in this project.

Modifications:
Added nsp to the CI configuration (Travis).

Result:
nsp check will be run as part of CI

JIRA:
https://issues.jboss.org/browse/RAINCATCH-206