### PR TITLE
Turns off auto-complete for password field

### DIFF
--- a/src/app/auth/login.tpl.html
+++ b/src/app/auth/login.tpl.html
@@ -14,7 +14,7 @@
         </md-input-container>
         <md-input-container class="md-block">
           <label>Password</label>
-          <input ng-model="ctrl.password" id="password" name="password" type="password" required>
+          <input ng-model="ctrl.password" id="password" name="password" type="password" autocomplete="off" required>
           <div ng-messages="loginForm.password.$error" ng-show="loginForm.$submitted || loginForm.password.$dirty">
             <div ng-message="required">A password is required.</div>
           </div>


### PR DESCRIPTION
Disables the auto-completion of the password field in raincatcher-demo-mobile by specifying autocomplete="off" on the password field in the login view

Part of the JIRA: https://issues.jboss.org/browse/RAINCATCH-407
(rest of JIRA is to do the same for raincatcher-demo-portal & raincatcher-demo-user)

@TommyJ1994 @witmicko can you take a look if you get a chance & see if ok