### PR TITLE
remove travis nsp checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ services:
 node_js:
   - '0.10'
   - '4.4'
+before_install:
+  - npm install grunt-cli -g
+install: npm install
 script:
   - npm test
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
-install: npm install
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ node_js:
   - '4.4'
 script:
   - npm test
-  - npm run vuln; exit 0
   - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 install: npm install
 notifications:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -452,7 +452,7 @@
             },
             "mime-types": {
               "version": "2.1.14",
-              "from": "mime-types@>=2.1.13 <2.2.0",
+              "from": "mime-types@>=2.1.11 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
               "dependencies": {
                 "mime-db": {
@@ -531,9 +531,9 @@
           "resolved": "https://registry.npmjs.org/base64-stream/-/base64-stream-0.1.3.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "2.2.2",
+              "version": "2.2.3",
               "from": "readable-stream@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
@@ -637,7 +637,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "typedarray": {
@@ -646,9 +646,9 @@
                   "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 },
                 "readable-stream": {
-                  "version": "2.2.2",
+                  "version": "2.2.3",
                   "from": "readable-stream@>=2.2.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
@@ -2716,9 +2716,9 @@
           }
         },
         "mongodb": {
-          "version": "2.2.23",
+          "version": "2.2.24",
           "from": "mongodb@>=2.2.16 <3.0.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.23.tgz",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.24.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "npm": "2.0.0"
   },
   "scripts": {
-    "test": "grunt eslint",
-    "vuln": "nsp check"
+    "test": "grunt eslint"
   },
   "keywords": [
     "wfm"
@@ -67,7 +66,6 @@
     "grunt-rev": "0.1.0",
     "grunt-sass": "1.1.0",
     "load-grunt-tasks": "3.4.1",
-    "nsp": "^2.6.2",
     "time-grunt": "1.3.0",
     "uglifyify": "^3.0.1"
   }


### PR DESCRIPTION
**Motivation**
NSP was obsoleted by using snyk for checking vulnerabilities in dependencies. Currently the hack done for it to be an 'optional' check i.e. not fail builds is actually making CI builds that are supposed to fail pass.

- regenerate shrinkwrap