### PR TITLE
RHMAP-15272 - sync does not allow overwriting sync options per dataset 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "angular-ui-router": "0.4.2",
     "async": "1.5.2",
     "debug": "^2.6.3",
-    "fh-js-sdk": "2.18.4",
+    "fh-js-sdk": "2.18.5-alpha.15272.2",
     "fh-wfm-camera": "0.0.10",
     "fh-wfm-file": "0.4.0",
     "fh-wfm-file-angular": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "angular-ui-router": "0.4.2",
     "async": "1.5.2",
     "debug": "^2.6.3",
-    "fh-js-sdk": "2.18.6-alpha.15272.1",
+    "fh-js-sdk": "2.18.6",
     "fh-wfm-camera": "0.0.10",
     "fh-wfm-file": "0.4.0",
     "fh-wfm-file-angular": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "angular-ui-router": "0.4.2",
     "async": "1.5.2",
     "debug": "^2.6.3",
-    "fh-js-sdk": "2.18.5-alpha.15272.2",
+    "fh-js-sdk": "2.18.6-alpha.15272.1",
     "fh-wfm-camera": "0.0.10",
     "fh-wfm-file": "0.4.0",
     "fh-wfm-file-angular": "0.1.2",

--- a/src/app/config.json
+++ b/src/app/config.json
@@ -4,9 +4,26 @@
     "workflows": "workflows",
     "results": "result"
   },
-  "syncOptions": {
-    "sync_frequency": 5,
-    "storage_strategy": "dom",
-    "do_console_log": false
+  "syncOptions" : {
+    "global":{
+      "sync_frequency" : 7,
+      "storage_strategy": "dom",
+      "do_console_log": false
+    },
+    "workorders":{
+      "sync_frequency" : 5,
+      "storage_strategy": "dom",
+      "do_console_log": false
+    },
+    "workflows":{
+      "sync_frequency" : 5,
+      "storage_strategy": "dom",
+      "do_console_log": false
+    },
+    "results":{
+      "sync_frequency" : 5,
+      "storage_strategy": "dom",
+      "do_console_log": false
+    }
   }
 }

--- a/src/app/initialisation/syncPoolService.js
+++ b/src/app/initialisation/syncPoolService.js
@@ -49,9 +49,9 @@ function SyncPoolService($q, mediator, syncService) {
 
     //Initialisation of sync data sets to manage.
     return $q.all([
-      syncService.manage(config.datasetIds.workorders, config.syncOptions, {filter: filter}, {}),
-      syncService.manage(config.datasetIds.workflows, config.syncOptions, {}, {}),
-      syncService.manage(config.datasetIds.results, config.syncOptions, {}, {})
+      syncService.manage(config.datasetIds.workorders, config.syncOptions.workorders, {filter: filter}, {}),
+      syncService.manage(config.datasetIds.workflows, config.syncOptions.workflows, {}, {}),
+      syncService.manage(config.datasetIds.results, config.syncOptions.results, {}, {})
     ]).then(function(managers) {
       managers.forEach(function(managerWrapper) {
         syncManagers[managerWrapper.manager.datasetId] = managerWrapper;


### PR DESCRIPTION
# What
sync was resetting dataset.config to global sync config

# How
- added config per dataset
- changed order of parameters in `sync.manage`

# JIRA
https://issues.jboss.org/browse/RHMAP-15272

# Related PRs
https://github.com/feedhenry/fh-js-sdk/pull/206

@nialldonnellyfh 
@wtrocki 