### PR TITLE
Refactored app initialisation to validate sessions on resuming

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fh-wfm-risk-assessment": "0.0.18",
     "fh-wfm-signature": "0.0.19",
     "fh-wfm-sync": "1.0.0",
-    "fh-wfm-user": "0.6.4",
+    "fh-wfm-user": "0.6.5",
     "fh-wfm-user-angular": "0.2.5",
     "fh-wfm-vehicle-inspection": "0.0.15",
     "fh-wfm-workflow": "0.2.5",

--- a/src/app/initialisation/config.js
+++ b/src/app/initialisation/config.js
@@ -1,6 +1,10 @@
 function createMainAppRoute($stateProvider, $urlRouterProvider) {
   // if none of the states are matched, use this as the fallback
-  $urlRouterProvider.otherwise('/workorders/list');
+
+  $urlRouterProvider.otherwise( function($injector) {
+    var $state = $injector.get("$state");
+    $state.go("app.workorder");
+  });
 
   $stateProvider
     .state('app', {


### PR DESCRIPTION
# Motivation

When the app loads, there is no guarantee that the session is valid.

Therefore, the session has to be verified when the app loads

# Changes

When changing state `$stateChangeStart`, there needs to be at least one verification of the session the user is logged in as.

If the session is not valid, the user should be redirected to the login screen.

Also incorporates https://github.com/feedhenry-raincatcher/raincatcher-user/pull/70