### PR TITLE
RHMAP-15320 - include session in workorder query filter

### DIFF
--- a/src/app/initialisation/syncPoolService.js
+++ b/src/app/initialisation/syncPoolService.js
@@ -42,7 +42,8 @@ function SyncPoolService($q, mediator, syncService) {
 
     var filter = {
       key: 'assignee',
-      value: profileData.sessionToken
+      value: profileData.id,
+      sessionToken: profileData.sessionToken
     };
 
     //Initialisation of sync data sets to manage.

--- a/src/app/initialisation/syncPoolService.js
+++ b/src/app/initialisation/syncPoolService.js
@@ -40,12 +40,11 @@ function SyncPoolService($q, mediator, syncService) {
 
     syncManagers = {};
 
-    if (profileData && profileData.id) {
-      var filter = {
-        key: 'assignee',
-        value: profileData.id
-      };
-    }
+    var filter = {
+      key: 'assignee',
+      value: profileData.id,
+      sessionToken: profileData.sessionToken
+    };
 
     //Initialisation of sync data sets to manage.
     return $q.all([

--- a/src/app/initialisation/syncPoolService.js
+++ b/src/app/initialisation/syncPoolService.js
@@ -42,8 +42,7 @@ function SyncPoolService($q, mediator, syncService) {
 
     var filter = {
       key: 'assignee',
-      value: profileData.id,
-      sessionToken: profileData.sessionToken
+      value: profileData.sessionToken
     };
 
     //Initialisation of sync data sets to manage.


### PR DESCRIPTION
# Motivation

Allow to query using user session. Token can be used later in cloud to check if proper user is authenticated. Token is also passed as header but due to fh-sync limitations we cannot retrieve it later so it needs to be passed explicitly. 

# Notes

Filtering by token will be handled in data layer by developers.